### PR TITLE
Be more cautious when talking about RSA key sizes

### DIFF
--- a/site/docs/tutorial-09crypto.html
+++ b/site/docs/tutorial-09crypto.html
@@ -77,7 +77,9 @@ const decrypted = await key.decrypt(encrypted, 'aes256')
 decrypted.toString() // -> hello world
 </code></pre>
 <h2>Signing &amp; Verification</h2>
-<p>You can also use a multi-factor derived key to encrypt secrets using RSA1024, RSA2048, or RSA3072. RSA1024, demonstrated below, is highly recommended for efficiency reasons:</p>
+<p>you can also use a multi-factor derived key to encrypt secrets using rsa1024, rsa2048, or rsa3072. In this tutorial we use rsa1024 due to its speed, but for a real-world scenario use the sizes that are deemed secure at the time of use (i.e., at least RSA2048 at the time of writing):
+</p>
+
 <pre class="prettyprint source"><code>// setup 3-factor multi-factor derived key
 const key = await mfkdf.setup.key([
   await mfkdf.setup.factors.password('password'),


### PR DESCRIPTION
I understand that the tutorial is not trying to show the production-level quality --- e.g., the `password` is often set to `"password"`. One would hope that for the password examples the users are by now aware that `"password"` is not a strong password :)

However, I am a bit more doubtful about the other cryptographic primitives such as RSA. Therefore, I suggest to err on the side of caution and be more explicit about RSA.