### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "standard": "^17.0.0",
         "stream-browserify": "^3.0.0",
         "terser": "^5.10.0",
+        "tsd": "^0.33.0",
         "url": "^0.11.0",
         "util": "^0.12.4",
         "vm-browserify": "^1.1.2",
@@ -1032,6 +1033,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1185,6 +1199,13 @@
         }
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -1196,6 +1217,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@tsd/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-JSSdNiS0wgd8GHhBwnMAI18Y8XPhLVN+dNelPfZCXFhy9Lb3NbnFyp9JKxxr54jSUkEJPk3cidvCoHducSaRMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@types/eslint": {
@@ -1261,6 +1292,13 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.3.1",
@@ -1756,6 +1794,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/asn1.js": {
@@ -2379,6 +2427,24 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3064,6 +3130,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -3277,6 +3370,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/diffie-hellman": {
@@ -3725,6 +3828,99 @@
         "eslint-plugin-react": "^7.28.0"
       }
     },
+    "node_modules/eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -4036,6 +4232,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/eslint-rule-docs": {
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -4948,6 +5151,16 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5592,6 +5805,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/irregular-plurals": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -5914,6 +6137,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -6275,6 +6508,62 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-worker": {
@@ -6872,6 +7161,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
@@ -7041,6 +7343,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7070,6 +7382,21 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -8753,6 +9080,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "irregular-plurals": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8771,6 +9114,41 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -8892,6 +9270,16 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/randexp": {
       "version": "0.5.3",
@@ -9027,6 +9415,149 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/read-pkg/node_modules/parse-json": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
@@ -9094,6 +9625,30 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -9843,6 +10398,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10135,6 +10703,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -10187,6 +10765,123 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tsd": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.33.0.tgz",
+      "integrity": "sha512-/PQtykJFVw90QICG7zyPDMIyueOXKL7jOJVoX5pILnb3Ux+7QqynOxfVvarE+K+yi7BZyOSY4r+OZNWSWRiEwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tsd/typescript": "^5.9.2",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "jest-diff": "^29.0.3",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "bin": {
+        "tsd": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/tsd/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tsd/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tsd/node_modules/meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsd/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tsd/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tsd/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tslib": {
@@ -10918,6 +11613,13 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -11680,6 +12382,15 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.27.8"
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -11792,10 +12503,22 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true
+    },
     "@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true
+    },
+    "@tsd/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-JSSdNiS0wgd8GHhBwnMAI18Y8XPhLVN+dNelPfZCXFhy9Lb3NbnFyp9JKxxr54jSUkEJPk3cidvCoHducSaRMQ==",
       "dev": true
     },
     "@types/eslint": {
@@ -11856,6 +12579,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true
     },
     "@types/node": {
@@ -12236,6 +12965,12 @@
         "es-abstract": "^1.19.2",
         "es-shim-unscopables": "^1.0.0"
       }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -12684,6 +13419,17 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
     },
     "caniuse-lite": {
       "version": "1.0.30001741",
@@ -13203,6 +13949,24 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "dev": true
+        }
+      }
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -13338,6 +14102,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true
     },
     "diffie-hellman": {
@@ -13726,6 +14496,68 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/eslint": {
+          "version": "7.29.0",
+          "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+          "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "*",
+            "@types/json-schema": "*"
+          }
+        },
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -13965,6 +14797,12 @@
           }
         }
       }
+    },
+    "eslint-rule-docs": {
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -14531,6 +15369,12 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -14996,6 +15840,12 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
     },
+    "irregular-plurals": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
+      "dev": true
+    },
     "is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -15185,6 +16035,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true
     },
     "is-plain-object": {
@@ -15438,6 +16294,45 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -15903,6 +16798,12 @@
         "semver": "^6.0.0"
       }
     },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
     "markdown-it": {
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
@@ -16025,6 +16926,12 @@
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -16051,6 +16958,17 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -17228,6 +18146,15 @@
         }
       }
     },
+    "plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^3.2.0"
+      }
+    },
     "possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -17239,6 +18166,31 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+          "dev": true
+        }
+      }
     },
     "process": {
       "version": "0.11.10",
@@ -17325,6 +18277,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
     "randexp": {
@@ -17446,6 +18404,109 @@
         }
       }
     },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -17473,6 +18534,24 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        }
       }
     },
     "regexp.prototype.flags": {
@@ -17990,6 +19069,15 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -18186,6 +19274,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
+    },
     "trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -18228,6 +19322,85 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+          "dev": true
+        }
+      }
+    },
+    "tsd": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.33.0.tgz",
+      "integrity": "sha512-/PQtykJFVw90QICG7zyPDMIyueOXKL7jOJVoX5pILnb3Ux+7QqynOxfVvarE+K+yi7BZyOSY4r+OZNWSWRiEwQ==",
+      "dev": true,
+      "requires": {
+        "@tsd/typescript": "^5.9.2",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "jest-diff": "^29.0.3",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "meow": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+          "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+          "dev": true,
+          "requires": {
+            "@types/minimist": "^1.2.0",
+            "camelcase-keys": "^6.2.2",
+            "decamelize": "^1.2.0",
+            "decamelize-keys": "^1.1.0",
+            "hard-rejection": "^2.1.0",
+            "minimist-options": "4.1.0",
+            "normalize-package-data": "^3.0.0",
+            "read-pkg-up": "^7.0.1",
+            "redent": "^3.0.0",
+            "trim-newlines": "^3.0.0",
+            "type-fest": "^0.18.0",
+            "yargs-parser": "^20.2.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+          "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
           "dev": true
         }
       }
@@ -18746,6 +19919,12 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "2.0.0-13",
   "description": "JavaScript Implementation of a Next-Generation Multi-Factor Key Derivation Function (MFKDF2)",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "engines": {
     "node": ">= 16"
   },
   "scripts": {
     "pages:build": "npm run test && npm run docs && cd site/mfkdf2 && npm ci && npm run build",
-    "test": "npm run style && npm run coverage",
+    "test": "npm run style && npm run types && npm run coverage",
     "style": "standard ./src --fix && standard ./test --fix",
+    "types": "tsd",
     "unit": "mocha",
     "coverage": "nyc --report-dir=\"./site/mfkdf2/public/nyc\" --reporter=text --reporter=html mocha --branches 100",
     "version": "npm run docs && git add site && npm run build && git add mfkdf.js && git add mfkdf.min.js",
@@ -55,6 +57,7 @@
     "standard": "^17.0.0",
     "stream-browserify": "^3.0.0",
     "terser": "^5.10.0",
+    "tsd": "^0.33.0",
     "url": "^0.11.0",
     "util": "^0.12.4",
     "vm-browserify": "^1.1.2",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,562 @@
+/**
+ * Type definitions for MFKDF (Multi-Factor Key Derivation Function) v2.
+ *
+ * These declarations are hand-written to mirror the JSDoc-annotated public API
+ * in src/. Consumers need `@types/node` available for the global `Buffer` type.
+ *
+ * @see https://mfkdf.com
+ */
+
+/// <reference types="node" />
+
+export = mfkdf
+export as namespace mfkdf
+
+declare namespace mfkdf {
+  // ===========================================================================
+  // Core types
+  // ===========================================================================
+
+  /** Async function returning a factor's public parameters. */
+  type MFKDFFactorParams = (
+    config: { key: Buffer }
+  ) => Promise<Record<string, unknown>>
+
+  /** Async function returning a factor's output (generic/derive side). */
+  type MFKDFFactorOutput = () => Promise<Record<string, unknown>>
+
+  /** `output()` of a password or security-question factor. */
+  interface StrengthFactorOutput {
+    /** zxcvbn strength estimate of the input. */
+    strength: Record<string, unknown>
+  }
+  /** `output()` of a HOTP factor — provisioning details for the authenticator. */
+  interface HOTPFactorOutput {
+    scheme: 'otpauth'
+    type: 'hotp'
+    label: string
+    secret: Buffer
+    issuer: string
+    algorithm: HashAlgorithm
+    digits: number
+    counter: number
+    uri: string
+  }
+  /** `output()` of a TOTP factor — provisioning details for the authenticator. */
+  interface TOTPFactorOutput {
+    scheme: 'otpauth'
+    type: 'totp'
+    label: string
+    secret: Buffer
+    issuer: string
+    algorithm: HashAlgorithm
+    digits: number
+    period: number
+    uri: string
+  }
+
+  /** Fields shared by every setup-produced factor. */
+  interface MFKDFFactorBase {
+    /** Unique identifier of this factor. */
+    id: string
+    /** Key material for this factor. */
+    data: Buffer
+    /** Asynchronous function to fetch the public parameters for this factor. */
+    params: MFKDFFactorParams
+    /** Actual bits of entropy this factor provides. */
+    entropy: number
+  }
+
+  interface PasswordFactor extends MFKDFFactorBase {
+    type: 'password'
+    output: () => Promise<StrengthFactorOutput>
+  }
+  interface QuestionFactor extends MFKDFFactorBase {
+    type: 'question'
+    output: () => Promise<StrengthFactorOutput>
+  }
+  interface UUIDFactor extends MFKDFFactorBase {
+    type: 'uuid'
+    output: () => Promise<{ uuid: string }>
+  }
+  interface PasskeyFactor extends MFKDFFactorBase {
+    type: 'passkey'
+    output: () => Promise<Record<string, never>>
+  }
+  interface OOBAFactor extends MFKDFFactorBase {
+    type: 'ooba'
+    output: () => Promise<Record<string, never>>
+  }
+  interface HMACSHA1Factor extends MFKDFFactorBase {
+    type: 'hmacsha1'
+    output: () => Promise<{ secret: Buffer }>
+  }
+  interface HOTPFactor extends MFKDFFactorBase {
+    type: 'hotp'
+    output: () => Promise<HOTPFactorOutput>
+  }
+  interface TOTPFactor extends MFKDFFactorBase {
+    type: 'totp'
+    output: () => Promise<TOTPFactorOutput>
+  }
+  interface StackFactor extends MFKDFFactorBase {
+    type: 'stack'
+    /** A stacked factor's output is the nested derived key. */
+    output: () => Promise<MFKDFDerivedKey>
+  }
+
+  /**
+   * A factor produced by `setup.factors.*` or a `policy` combinator and
+   * consumed by `setup.key` / `addFactor` / `recoverFactor`. Discriminated on
+   * `type`: narrowing reveals the precise `output()` return for that factor
+   * (e.g. an `otpauth` object for HOTP/TOTP, `{ strength }` for password).
+   */
+  type MFKDFFactor =
+    | PasswordFactor
+    | QuestionFactor
+    | UUIDFactor
+    | PasskeyFactor
+    | OOBAFactor
+    | HMACSHA1Factor
+    | HOTPFactor
+    | TOTPFactor
+    | StackFactor
+
+  /**
+   * The factor object obtained by resolving a derive-side function. Unlike a
+   * setup {@link MFKDFFactor} it carries no id or entropy estimate, and the
+   * `persisted` factor has no output.
+   */
+  interface MFKDFDerivedFactor {
+    /** Includes `'persisted'` in addition to the standard factor types. */
+    type: MFKDFFactorType | 'persisted'
+    data: Buffer
+    params: MFKDFFactorParams
+    /** Absent for the `persisted` factor. */
+    output?: MFKDFFactorOutput
+  }
+
+  /**
+   * A derive-side factor: an async function which, given the policy's factor
+   * config, resolves to the {@link MFKDFDerivedFactor} used to reconstruct the
+   * key.
+   */
+  type MFKDFFactorDerive = (
+    config: Record<string, unknown>
+  ) => Promise<MFKDFDerivedFactor>
+
+  /** Hash algorithm accepted by the HOTP/TOTP factors. */
+  type HashAlgorithm = 'sha1' | 'sha256' | 'sha512'
+
+  /** The `type` tag shared by every factor and policy entry. */
+  type MFKDFFactorType =
+    | 'password'
+    | 'uuid'
+    | 'passkey'
+    | 'question'
+    | 'hotp'
+    | 'totp'
+    | 'hmacsha1'
+    | 'ooba'
+    | 'stack'
+
+  /** Fields common to every policy factor entry. */
+  interface MFKDFFactorPolicyBase {
+    /** Unique identifier of this factor within the policy. */
+    id: string
+    /** Encrypted pad (base64). */
+    pad?: string
+    /** Encrypted factor secret (base64). */
+    secret?: string
+    /** Per-factor salt (base64). */
+    salt?: string
+    /** Optional low-entropy hint stored for this factor. */
+    hint?: string
+  }
+
+  interface PasswordFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'password'
+    params: Record<string, never>
+  }
+  interface UUIDFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'uuid'
+    params: Record<string, never>
+  }
+  interface PasskeyFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'passkey'
+    params: Record<string, never>
+  }
+  interface QuestionFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'question'
+    params: { question?: string }
+  }
+  interface HOTPFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'hotp'
+    params: {
+      hash: HashAlgorithm
+      digits: number
+      pad: string
+      counter: number
+      offset: number
+    }
+  }
+  interface TOTPFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'totp'
+    params: {
+      start: number
+      hash: HashAlgorithm
+      digits: number
+      step: number
+      window: number
+      pad: string
+      offsets: string
+    }
+  }
+  interface HMACSHA1FactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'hmacsha1'
+    params: { challenge: string; pad: string }
+  }
+  interface OOBAFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'ooba'
+    params: {
+      length: number
+      /** Exported JWK of the out-of-band channel public key. */
+      key: Record<string, unknown>
+      params: Record<string, unknown>
+      /** Next encrypted code (hex). */
+      next: string
+      pad: string
+    }
+  }
+  interface StackFactorPolicy extends MFKDFFactorPolicyBase {
+    type: 'stack'
+    /** A stacked factor embeds a full nested policy as its params. */
+    params: MFKDFPolicy
+  }
+
+  /**
+   * A single factor entry within a key policy. Discriminated on `type`: narrow
+   * with `if (factor.type === 'hotp') { factor.params.digits }`.
+   */
+  type MFKDFFactorPolicy =
+    | PasswordFactorPolicy
+    | UUIDFactorPolicy
+    | PasskeyFactorPolicy
+    | QuestionFactorPolicy
+    | HOTPFactorPolicy
+    | TOTPFactorPolicy
+    | HMACSHA1FactorPolicy
+    | OOBAFactorPolicy
+    | StackFactorPolicy
+
+  /** A serializable key policy describing how a key is derived. */
+  interface MFKDFPolicy {
+    $schema?: string
+    $id?: string
+    threshold?: number
+    salt?: string
+    hmac?: string
+    kdf?: Record<string, unknown>
+    factors: MFKDFFactorPolicy[]
+    [key: string]: unknown
+  }
+
+  /** Entropy estimate (in bits) for a derived key. */
+  interface MFKDFEntropyBits {
+    theoretical: number
+    real: number
+  }
+
+  // ===========================================================================
+  // MFKDFDerivedKey class
+  // ===========================================================================
+
+  /**
+   * A multi-factor derived key and the operations available on it.
+   *
+   * Instances are only ever produced by the library (`setup.key`,
+   * `derive.key`, `policy.setup`, `policy.derive`) — the constructor is not
+   * exported, so this is declared as an interface rather than a class.
+   */
+  interface MFKDFDerivedKey {
+    /** The policy used to derive this key. */
+    policy: MFKDFPolicy
+    /** The value of this derived key. */
+    key: Buffer
+    /** The secret (pre-KDF) value of this derived key. */
+    secret: Buffer
+    /** The shares corresponding to the factors of this key. */
+    shares: Buffer[]
+    /** The outputs corresponding to the factors of this key. */
+    outputs: Array<Record<string, unknown>>
+    /** Entropy estimate for this key. Present only on keys produced by setup. */
+    entropyBits?: MFKDFEntropyBits
+
+    // --- Crypto ---
+    /** Derive a sub-key from this key for a given purpose/salt. */
+    getSubkey(purpose?: string, salt?: string): Promise<Buffer>
+
+    // --- Reconstitution ---
+    /** Change the number of factors required to derive this key. */
+    setThreshold(threshold: number): Promise<void>
+    /** Remove an existing factor by id. */
+    removeFactor(id: string): Promise<void>
+    /** Remove several existing factors by id. */
+    removeFactors(ids: string[]): Promise<void>
+    /** Add a new factor to this key. */
+    addFactor(factor: MFKDFFactor): Promise<void>
+    /** Add several new factors to this key. */
+    addFactors(factors: MFKDFFactor[]): Promise<void>
+    /** Replace (recover) an existing factor with a new one. */
+    recoverFactor(factor: MFKDFFactor): Promise<void>
+    /** Replace (recover) several existing factors. */
+    recoverFactors(factors: MFKDFFactor[]): Promise<void>
+    /** Add/remove factors and/or adjust the threshold in one operation. */
+    reconstitute(
+      removeFactors?: string[],
+      addFactors?: MFKDFFactor[],
+      threshold?: number
+    ): Promise<void>
+
+    // --- Persistence ---
+    /** Persist a factor, returning the share that can be used to bypass it. */
+    persistFactor(id: string): Buffer
+
+    // --- Strengthening ---
+    /** Add additional argon2 time/memory cost to this key. */
+    strengthen(time?: number, memory?: number): Promise<void>
+
+    // --- Multi-factor derived password generation (MFDPG) ---
+    /** Derive a deterministic password matching the given regex policy. */
+    derivePassword(purpose: string, salt: string, regex: RegExp): Promise<string>
+
+    // --- Hints ---
+    /** Compute a hint (low-entropy prefix) for a factor without storing it. */
+    getHint(factor: string, bits?: number): Promise<string>
+    /** Compute and store a hint for a factor in the policy. */
+    addHint(factor: string, bits?: number): Promise<void>
+  }
+
+  // ===========================================================================
+  // setup
+  // ===========================================================================
+
+  namespace setup {
+    interface KeyOptions {
+      /** Unique identifier for this key; random UUIDv4 by default. */
+      id?: string
+      /** Number of factors required to derive key; all by default. */
+      threshold?: number
+      /** Cryptographic salt; securely generated by default. */
+      salt?: Buffer
+      /** Whether to sign the resulting key policy (recommended). */
+      integrity?: boolean
+      /** Additional rounds of argon2 time cost to add; 0 by default. */
+      time?: number
+      /** Additional argon2 memory cost to add (in KiB); 0 by default. */
+      memory?: number
+    }
+
+    /** Validate and set up a configuration for a multi-factor derived key. */
+    function key(
+      factors: MFKDFFactor[],
+      options?: KeyOptions
+    ): Promise<MFKDFDerivedKey>
+
+    namespace factors {
+      interface PasswordOptions {
+        id?: string
+      }
+      function password(
+        password: string,
+        options?: PasswordOptions
+      ): Promise<PasswordFactor>
+
+      interface UUIDOptions {
+        /** UUID to use; random v4 UUID by default. */
+        uuid?: string
+        id?: string
+      }
+      function uuid(options?: UUIDOptions): Promise<UUIDFactor>
+
+      interface HOTPOptions {
+        id?: string
+        hash?: HashAlgorithm
+        digits?: number
+        secret?: Buffer
+        issuer?: string
+        label?: string
+      }
+      function hotp(options?: HOTPOptions): Promise<HOTPFactor>
+
+      interface TOTPOptions {
+        id?: string
+        hash?: HashAlgorithm
+        digits?: number
+        secret?: Buffer
+        issuer?: string
+        label?: string
+        /** Current time for TOTP; defaults to Date.now(). */
+        time?: number
+        /** Max window between logins, in steps (1 month by default). */
+        window?: number
+        /** TOTP step size. */
+        step?: number
+        /** Timing oracle offsets to use; none by default. */
+        oracle?: Record<string, unknown>
+      }
+      function totp(options?: TOTPOptions): Promise<TOTPFactor>
+
+      interface StackOptions {
+        id?: string
+        threshold?: number
+        salt?: Buffer
+      }
+      function stack(
+        factors: MFKDFFactor[],
+        options?: StackOptions
+      ): Promise<StackFactor>
+
+      interface HMACSHA1Options {
+        id?: string
+        secret?: Buffer
+      }
+      function hmacsha1(options?: HMACSHA1Options): Promise<HMACSHA1Factor>
+
+      interface QuestionOptions {
+        /** Security question corresponding to this factor. */
+        question?: string
+        id?: string
+      }
+      function question(
+        answer: string,
+        options?: QuestionOptions
+      ): Promise<QuestionFactor>
+
+      interface OOBAOptions {
+        id?: string
+        /** Number of characters to use in one-time codes. */
+        length?: number
+        /** Public key of out-of-band channel. */
+        key: CryptoKey
+        /** Parameters to provide to the out-of-band channel. */
+        params: Record<string, unknown>
+      }
+      function ooba(options: OOBAOptions): Promise<OOBAFactor>
+
+      interface PasskeyOptions {
+        id?: string
+      }
+      /** Derive a factor from a 256-bit WebAuthn PRF secret. */
+      function passkey(
+        secret: Buffer,
+        options?: PasskeyOptions
+      ): Promise<PasskeyFactor>
+    }
+  }
+
+  // ===========================================================================
+  // derive
+  // ===========================================================================
+
+  namespace derive {
+    /** Derive a key from a policy and the supplied factors. */
+    function key(
+      policy: MFKDFPolicy,
+      factors: Record<string, MFKDFFactorDerive>,
+      verify?: boolean
+    ): Promise<MFKDFDerivedKey>
+
+    namespace factors {
+      function password(password: string): MFKDFFactorDerive
+      function uuid(uuid: string): MFKDFFactorDerive
+      function hotp(code: number): MFKDFFactorDerive
+      function totp(
+        code: number,
+        options?: { time?: number; oracle?: Record<string, unknown> }
+      ): MFKDFFactorDerive
+      function stack(
+        factors: Record<string, MFKDFFactorDerive>
+      ): MFKDFFactorDerive
+      /** Bypass a factor using its persisted share. */
+      function persisted(share: Buffer): MFKDFFactorDerive
+      function hmacsha1(response: Buffer): MFKDFFactorDerive
+      function question(answer: string): MFKDFFactorDerive
+      function ooba(code: number): MFKDFFactorDerive
+      function passkey(secret: Buffer): MFKDFFactorDerive
+    }
+  }
+
+  // ===========================================================================
+  // secrets (Shamir secret sharing)
+  // ===========================================================================
+
+  namespace secrets {
+    /** Split a secret into `n` shares, `k` of which are required. */
+    function share(secret: Buffer, k: number, n: number): Buffer[]
+    /** Combine `k`-of-`n` shares back into the original secret. */
+    function combine(shares: Buffer[], k: number, n: number): Buffer
+    /** Recover the original secret from a set of shares. */
+    function recover(shares: Buffer[], k: number, n: number): Buffer
+  }
+
+  // ===========================================================================
+  // policy (logic combinators & validation)
+  // ===========================================================================
+
+  namespace policy {
+    interface SetupOptions {
+      id?: string
+      threshold?: number
+      salt?: Buffer
+    }
+    /** Set up a key from a single (possibly composite) factor. */
+    function setup(
+      factor: MFKDFFactor,
+      options?: SetupOptions
+    ): Promise<MFKDFDerivedKey>
+
+    /** Derive a key from a policy using logic-combinator factors. */
+    function derive(
+      policy: MFKDFPolicy,
+      factors: Record<string, MFKDFFactorDerive>,
+      verify?: boolean
+    ): Promise<MFKDFDerivedKey>
+
+    /** Determine whether a key can be derived from the given factor ids. */
+    function evaluate(policy: MFKDFPolicy, factors: string[]): boolean
+    /** List the factor ids declared in a policy. */
+    function ids(policy: MFKDFPolicy): string[]
+    /** Validate that a policy is well-formed. */
+    function validate(policy: MFKDFPolicy): boolean
+
+    /** Factor satisfiable by either input factor. */
+    function or(factor1: MFKDFFactor, factor2: MFKDFFactor): Promise<MFKDFFactor>
+    /** Factor satisfiable only by both input factors. */
+    function and(factor1: MFKDFFactor, factor2: MFKDFFactor): Promise<MFKDFFactor>
+    /** Factor satisfiable only by all input factors. */
+    function all(factors: MFKDFFactor[]): Promise<MFKDFFactor>
+    /** Factor satisfiable by any one of the input factors. */
+    function any(factors: MFKDFFactor[]): Promise<MFKDFFactor>
+    /** Factor satisfiable by at least `n` of the input factors. */
+    function atLeast(n: number, factors: MFKDFFactor[]): Promise<MFKDFFactor>
+  }
+
+  // ===========================================================================
+  // stage (pre-computation helpers)
+  // ===========================================================================
+
+  namespace stage {
+    interface FactorStage {
+      /** Pre-compute the params/outputs of a setup factor. */
+      setup(factor: Promise<MFKDFFactor>, key?: Buffer): Promise<MFKDFFactor>
+      /** Pre-compute the outputs of a derive factor. */
+      derive(
+        factor: MFKDFFactorDerive,
+        params: Record<string, unknown>,
+        key?: Buffer
+      ): Promise<MFKDFFactorDerive>
+    }
+    const factor: FactorStage
+  }
+}

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,0 +1,231 @@
+import { expectType, expectError, expectAssignable } from 'tsd'
+import * as mfkdf from '..'
+import type {
+  MFKDFFactor,
+  MFKDFDerivedFactor,
+  MFKDFFactorDerive,
+  MFKDFFactorOutput,
+  MFKDFFactorType,
+  MFKDFFactorPolicy,
+  StrengthFactorOutput,
+  HOTPFactorOutput,
+  TOTPFactorOutput,
+  HashAlgorithm,
+  MFKDFDerivedKey,
+  MFKDFPolicy
+} from '..'
+
+// ===========================================================================
+// setup.factors — each returns its specific factor variant (assignable to
+// MFKDFFactor), discriminated on `type`.
+// ===========================================================================
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.password('pw'))
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.password('pw', { id: 'p' }))
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.uuid())
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.uuid({ id: 'r', uuid: 'x' }))
+expectAssignable<Promise<MFKDFFactor>>(
+  mfkdf.setup.factors.hotp({ digits: 6, hash: 'sha1', secret: Buffer.from('x') })
+)
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.totp({ step: 30, window: 1 }))
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.hmacsha1())
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.question('a', { question: 'q?' }))
+expectAssignable<Promise<MFKDFFactor>>(mfkdf.setup.factors.passkey(Buffer.alloc(32)))
+
+// hash option is a restricted union
+expectError(mfkdf.setup.factors.hotp({ hash: 'md5' }))
+// password requires a string argument
+expectError(mfkdf.setup.factors.password(123))
+// ooba requires its mandatory key + params
+expectError(mfkdf.setup.factors.ooba({ length: 6 }))
+
+// ===========================================================================
+// setup.key
+// ===========================================================================
+const setupPromise = mfkdf.setup.key(
+  [
+    await mfkdf.setup.factors.password('pw', { id: 'p' }),
+    await mfkdf.setup.factors.uuid({ id: 'r' })
+  ],
+  { threshold: 2, time: 0, memory: 0, integrity: true }
+)
+expectType<Promise<MFKDFDerivedKey>>(setupPromise)
+const key = await setupPromise
+
+// first argument must be an array of factors, not a single factor
+expectError(mfkdf.setup.key(await mfkdf.setup.factors.password('pw')))
+// unknown options are rejected
+expectError(mfkdf.setup.key([], { bogus: true }))
+
+// ===========================================================================
+// MFKDFDerivedKey members
+// ===========================================================================
+expectType<Buffer>(key.key)
+expectType<Buffer>(key.secret)
+expectType<MFKDFPolicy>(key.policy)
+expectType<Buffer[]>(key.shares)
+expectType<Promise<Buffer>>(key.getSubkey('purpose', 'salt'))
+expectType<Promise<Buffer>>(key.getSubkey())
+expectType<Buffer>(key.persistFactor('p'))
+expectType<Promise<void>>(key.setThreshold(2))
+expectType<Promise<void>>(key.addFactor(await mfkdf.setup.factors.password('x', { id: 'x' })))
+expectType<Promise<void>>(key.removeFactors(['p']))
+expectType<Promise<void>>(key.reconstitute(['p'], [], 1))
+expectType<Promise<void>>(key.strengthen(1, 1024))
+expectType<Promise<string>>(key.derivePassword('purpose', 'salt', /[a-z]{6}/))
+expectType<Promise<string>>(key.getHint('p'))
+expectType<Promise<void>>(key.addHint('p', 7))
+expectType<number | undefined>(key.entropyBits?.real)
+
+// ===========================================================================
+// derive.factors — each returns an MFKDFFactorDerive function
+// ===========================================================================
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.password('pw'))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.uuid('uuid'))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.hotp(123456))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.totp(123456, { time: 0 }))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.persisted(Buffer.alloc(32)))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.hmacsha1(Buffer.alloc(20)))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.question('a'))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.ooba(123456))
+expectType<MFKDFFactorDerive>(mfkdf.derive.factors.passkey(Buffer.alloc(32)))
+
+// hotp expects a numeric code, not a string
+expectError(mfkdf.derive.factors.hotp('123456'))
+
+// ===========================================================================
+// derive.key
+// ===========================================================================
+expectType<Promise<MFKDFDerivedKey>>(
+  mfkdf.derive.key(key.policy, {
+    password: mfkdf.derive.factors.password('pw')
+  })
+)
+expectType<Promise<MFKDFDerivedKey>>(
+  mfkdf.derive.key(key.policy, { password: mfkdf.derive.factors.password('pw') }, true)
+)
+
+// ===========================================================================
+// secrets
+// ===========================================================================
+expectType<Buffer[]>(mfkdf.secrets.share(Buffer.from('s'), 2, 3))
+expectType<Buffer>(mfkdf.secrets.combine([Buffer.alloc(1)], 2, 3))
+expectType<Buffer>(mfkdf.secrets.recover([Buffer.alloc(1)], 2, 3))
+
+// ===========================================================================
+// policy
+// ===========================================================================
+expectType<boolean>(mfkdf.policy.validate(key.policy))
+expectType<boolean>(mfkdf.policy.evaluate(key.policy, ['p']))
+expectType<string[]>(mfkdf.policy.ids(key.policy))
+expectType<Promise<MFKDFDerivedKey>>(mfkdf.policy.setup(await mfkdf.setup.factors.password('a', { id: 'a' })))
+
+const f1 = await mfkdf.setup.factors.password('a', { id: 'a' })
+const f2 = await mfkdf.setup.factors.password('b', { id: 'b' })
+expectType<Promise<MFKDFFactor>>(mfkdf.policy.or(f1, f2))
+expectType<Promise<MFKDFFactor>>(mfkdf.policy.and(f1, f2))
+expectType<Promise<MFKDFFactor>>(mfkdf.policy.all([f1, f2]))
+expectType<Promise<MFKDFFactor>>(mfkdf.policy.any([f1, f2]))
+expectType<Promise<MFKDFFactor>>(mfkdf.policy.atLeast(1, [f1, f2]))
+
+// ===========================================================================
+// stage
+// ===========================================================================
+expectType<Promise<MFKDFFactor>>(
+  mfkdf.stage.factor.setup(mfkdf.setup.factors.password('pw'))
+)
+expectType<Promise<MFKDFFactorDerive>>(
+  mfkdf.stage.factor.derive(mfkdf.derive.factors.password('pw'), {})
+)
+
+// MFKDFDerivedKey is type-only: the class is never exported at runtime,
+// so it must not be usable as a value (constructable / referenceable).
+expectError(new mfkdf.MFKDFDerivedKey(key.policy, key.key, key.secret, [], []))
+expectError(mfkdf.MFKDFDerivedKey)
+
+// ===========================================================================
+// MFKDFFactor shape — setup factors carry required id/entropy/output
+// ===========================================================================
+const factor = await mfkdf.setup.factors.password('pw')
+expectType<'password'>(factor.type)
+expectType<Buffer>(factor.data)
+expectType<string>(factor.id)
+expectType<number>(factor.entropy)
+expectAssignable<MFKDFFactor>(factor)
+
+// ===========================================================================
+// Discriminated union: factor output() return narrows on factor type
+// ===========================================================================
+// Per-factor return types at the call site (no narrowing needed).
+expectType<Promise<StrengthFactorOutput>>(factor.output())
+expectType<Promise<HOTPFactorOutput>>((await mfkdf.setup.factors.hotp()).output())
+expectType<Promise<TOTPFactorOutput>>((await mfkdf.setup.factors.totp()).output())
+expectType<Promise<{ uuid: string }>>((await mfkdf.setup.factors.uuid()).output())
+expectType<Promise<{ secret: Buffer }>>(
+  (await mfkdf.setup.factors.hmacsha1()).output()
+)
+expectType<Promise<MFKDFDerivedKey>>(
+  (
+    await mfkdf.setup.factors.stack([
+      await mfkdf.setup.factors.password('a', { id: 'a' })
+    ])
+  ).output()
+)
+
+// HOTP/TOTP output detail.
+const otp = await (await mfkdf.setup.factors.hotp()).output()
+expectType<'otpauth'>(otp.scheme)
+expectType<string>(otp.uri)
+expectType<HashAlgorithm>(otp.algorithm)
+expectType<Buffer>(otp.secret)
+expectType<number>(otp.counter)
+
+// Narrowing a generic MFKDFFactor reveals the right output shape.
+declare const anyFactor: MFKDFFactor
+if (anyFactor.type === 'totp') {
+  expectType<Promise<TOTPFactorOutput>>(anyFactor.output())
+  expectType<number>((await anyFactor.output()).period)
+}
+if (anyFactor.type === 'uuid') {
+  expectType<Promise<{ uuid: string }>>(anyFactor.output())
+}
+// TOTP output has `period`, HOTP has `counter` — not interchangeable.
+expectError(otp.period)
+
+// A partial/hand-built object is not a valid setup factor.
+expectError<MFKDFFactor>({ type: 'password', data: Buffer.alloc(0) })
+expectError(key.addFactor({ type: 'password', data: Buffer.alloc(0) }))
+
+// Resolving a derive factor yields the leaner MFKDFDerivedFactor shape.
+const derivedFactor = await mfkdf.derive.factors.password('pw')({})
+expectType<MFKDFDerivedFactor>(derivedFactor)
+expectType<MFKDFFactorType | 'persisted'>(derivedFactor.type)
+expectType<Buffer>(derivedFactor.data)
+// ...which has no id/entropy.
+expectError(derivedFactor.id)
+expectError(derivedFactor.entropy)
+expectAssignable<MFKDFFactorOutput | undefined>(derivedFactor.output)
+
+// ===========================================================================
+// Discriminated union: policy factor entries narrow on `type`
+// ===========================================================================
+const entry: MFKDFFactorPolicy = key.policy.factors[0]
+expectType<MFKDFFactorType>(entry.type)
+
+if (entry.type === 'hotp') {
+  expectType<number>(entry.params.digits)
+  expectType<number>(entry.params.counter)
+  expectType<HashAlgorithm>(entry.params.hash)
+}
+if (entry.type === 'totp') {
+  expectType<string>(entry.params.offsets)
+  expectType<number>(entry.params.window)
+}
+if (entry.type === 'question') {
+  expectType<string | undefined>(entry.params.question)
+}
+if (entry.type === 'stack') {
+  // a stacked factor embeds a full nested policy
+  expectType<MFKDFFactorPolicy[]>(entry.params.factors)
+}
+// Fields from the wrong variant are not accessible without narrowing.
+expectError(entry.params.digits)


### PR DESCRIPTION
Add src/index.d.ts covering the full public API (setup, derive, secrets, policy, stage, and the MFKDFDerivedKey class), with discriminated unions for policy factor entries and factor output() returns. Add a tsd type test suite (test-d/) and wire it into the test script via a new "types" npm script.